### PR TITLE
Add tick parameter to OnCombatLog hook

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -82,7 +82,7 @@ type Parser struct {
 	OnSetConVar func(obj *dota.CNETMsg_SetConVar)
 	OnVoiceData func(obj *dota.CSVCMsg_VoiceData)
 
-	OnCombatLog func(log CombatLogEntry)
+	OnCombatLog func(tick int, log CombatLogEntry)
 
 	OnTablename func(name string)
 
@@ -436,7 +436,7 @@ func (p *Parser) onGameEvent(tick int, obj *dota.CSVCMsg_GameEvent) {
 	case "dota_combatlog":
 		if p.OnCombatLog != nil {
 			if log := p.combatLogParser.parse(obj); log != nil {
-				p.OnCombatLog(log)
+				p.OnCombatLog(tick, log)
 			}
 		}
 	case "dota_chase_hero":

--- a/yasha_test.go
+++ b/yasha_test.go
@@ -111,7 +111,7 @@ func TestPublicMatchPatch684p1(t *testing.T) {
 
 	earthshakerDeaths := 0
 	spiritBreakerDeaths := 0
-	parser.OnCombatLog = func(entry CombatLogEntry) {
+	parser.OnCombatLog = func(tick int, entry CombatLogEntry) {
 		// t.Logf("OnCombatLog: %s: %+v", reflect.TypeOf(entry), entry)
 		switch log := entry.(type) {
 		case *CombatLogDeath:
@@ -186,7 +186,7 @@ func testReplayCase(t *testing.T, c *testCase) {
 	parser.OnChatEvent = func(n int, o *dota.CDOTAUserMsg_ChatEvent) {
 	}
 
-	parser.OnCombatLog = func(entry CombatLogEntry) {
+	parser.OnCombatLog = func(tick int, entry CombatLogEntry) {
 		switch log := entry.(type) {
 		case *CombatLogDeath:
 			if strings.HasPrefix(log.Target, "npc_dota_hero_") {


### PR DESCRIPTION
Currently there is no reliable method to get the exact tick a combat log event occurred. The `Time` and `TimeRaw` fields in the different combat log messages cannot be used for this, there seems to be some magical offset which differs in every replay.
Fortunately, the function calling the `OnCombatLog` hook (`onGameEvent`) does know the tick at which the game event message containing the combat log message was sent. Simply passing this tick to the `OnCombatLog` call (and changing the signature of this hook accordingly) would supply the exact tick for every combat log message.
